### PR TITLE
非同期通信を使用しコメント投稿機能を作成

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,63 @@
+$(function(){
+  function buildHTML(message){
+    if(message.image != null){
+      var html = `<div class='message'>
+                  <div class='message__upper-info'>
+                    <div class='message__upper-info__talker'>
+                      ${message.user_name}
+                    </div>
+                    <div class='message__upper-info__date'>
+                      ${message.created_at}
+                    </div>
+                  </div>
+                  <p class='message__text'>
+                    ${message.content}
+                  </p>
+                  <img src='${message.image}', class='lower-message__image' width="200" height="109">
+                </div>`
+      return html;
+
+    }else{
+       var html = `<div class='message'>
+                  <div class='message__upper-info'>
+                    <div class='message__upper-info__talker'>
+                      ${message.user_name}
+                    </div>
+                    <div class='message__upper-info__date'>
+                      ${message.created_at}
+                    </div>
+                  </div>
+                  <p class='message__text'>
+                    ${message.content}
+                  </p>
+                </div>`
+      return html;
+    }
+  }
+
+$('#new_message').on('submit', function(e) {
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html)
+      $('.form__message').val('')
+      $('.form__submit').attr('disabled', false);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function(){
+      alert('メッセージを入力してください');
+      $('.form__submit').attr('disabled', false);
+    })
+  })
+})

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+  json.content  @message.content
+  json.user_id  @message.user.id
+  json.user_name  @message.user.name
+  json.created_at  @message.created_at.to_s(:datetime)
+  json.image  @message.image.url


### PR DESCRIPTION
# 実装内容
#### コメントと画像が投稿でき、投稿時コメントの一番下まで自動でスクロールされる。
#### コメント・画像が無く投稿ボタンが押された場合エラーアラートが表示される。
　
　
# 各ファイルの説明
### message.js
#### 画像投稿がある場合と無い場合の、２つのテンプレートリテラルを作成
---

### controller.rb
#### createアクションのレスポンスをJSONだけにする為にHTMLのレスポンスを削除
---

### create.json.jbuilder
データをJSON形式にしてJSファイルに返す
- content(投稿コメント)
- user_id(ユーザーID)
- user_name(ユーザーネーム)
- created_at(投稿日時)
- image(投稿画像)
---
　
　
# 非同期通信の動作確認
![9312b302033a84ae6aef9739606d4f25](https://user-images.githubusercontent.com/45912184/55527891-db5f7600-56d5-11e9-81fe-e7250e061678.gif)
